### PR TITLE
Improving the logic.

### DIFF
--- a/router.go
+++ b/router.go
@@ -154,7 +154,7 @@ func ValidateParams(params url.Values, desiredParams []Param) (map[string]string
 	paramValues := make(map[string]string)
 	for _, param := range desiredParams {
 		p, ok := params[param.Name]
-		if !ok && param.Required || p[0] == "" && param.Required {
+		if !ok || p[0] == "" && param.Required {
 			return nil, errors.New(fmt.Sprintf("Required parameter (%s) not valid", param.Name))
 		} else if ok && p[0] != "" {
 			paramValues[param.Name] = p[0]

--- a/router.go
+++ b/router.go
@@ -154,9 +154,9 @@ func ValidateParams(params url.Values, desiredParams []Param) (map[string]string
 	paramValues := make(map[string]string)
 	for _, param := range desiredParams {
 		p, ok := params[param.Name]
-		if !ok && param.Required && p[0] != "" {
+		if !ok && param.Required || p[0] == "" && param.Required {
 			return nil, errors.New(fmt.Sprintf("Required parameter (%s) not valid", param.Name))
-		} else if ok {
+		} else if ok && p[0] != "" {
 			paramValues[param.Name] = p[0]
 		}
 	}


### PR DESCRIPTION
If none of the desiredParams where passed in the URL the program would
get a runtime error “index out of range”

Now if the param is not there it will error specifying the param
correctly. It will now also return the param if it’s not required and
not blank. Because we loop through the desiredParams and not the params
passed we only return the requested ones and ignore the rest. Further
consideration is needed.
